### PR TITLE
Create initial template for foundations playbook.md

### DIFF
--- a/playbook.md
+++ b/playbook.md
@@ -1,0 +1,58 @@
+# DevRel Foundation's Governance Playbook
+
+Welcome to our governance playbook! This section provides a detailed documentation of the foundation's processes. It includes instructions on how to join a working group, file issues, and outlines the responsibilities of chairs. 
+For information on the general governance structure, please refer to our [charter]().
+
+- [Working Groups Guidelines](#working-groups)
+   -  Principles
+   -  Roles
+- [Communication Channel Guidelines](#communication-channel-guidelines)
+- [Linux Foundation's Policies](https://www.linuxfoundation.org/legal/policies)
+
+## Working Groups
+
+### Principles
+
+All Working Groups within the DevRel Foundation must 
+
+- Function with openness and transparency, meaning that participation is open to all, and minutes and other documents are available and easily accessible to everyone
+- Adhere to the DevRel Foundation’s Code of Conduct
+- Follows Linux Foundation's [Antitrust Policy](https://www.linuxfoundation.org/legal/antitrust-policy)
+
+### Roles
+
+#### Chairs
+
+Responsible for coordinating the activities of their respective working groups.
+
+Responsibiliteis include:
+
+- Facilitate meetings and set up the agenda
+- Ensure that discussions align with the yearly startegic goals previously approved by the Steering Committee
+- Provide quarterly updates to the Steering Committee and seeking guidance when necessary
+
+
+#### Steering Committee Members
+
+Responsible for overseeing the strategic direction.
+
+Responsibilities include:
+
+- Provide high-level guidance to working group
+- Approve major decisions
+- Resolve conflicts
+
+#### Working Group Contirbutors
+
+Contributors are the active participants of the working groups. They participate in discussions, contribute code or documentation, and other resources, collaborating with other participants to achieve the working group's strategic objectives
+
+Responsibilities include:
+
+- Attend Working Group Meetings on a regular basis
+- Review PRs and/or file issues
+- Participate in working group's communication channels
+
+## Communication Channel Guidelines
+
+TBD
+

--- a/playbook.md
+++ b/playbook.md
@@ -7,6 +7,7 @@ For information on the general governance structure, please refer to our [charte
    -  Principles
    -  Roles
 - [Communication Channel Guidelines](#communication-channel-guidelines)
+- [Steering Committee's Voting Process]()
 - [Linux Foundation's Policies](https://www.linuxfoundation.org/legal/policies)
 
 ## Working Groups

--- a/playbook.md
+++ b/playbook.md
@@ -26,11 +26,11 @@ All Working Groups within the DevRel Foundation must
 
 Responsible for coordinating the activities of their respective working groups.
 
-Responsibiliteis include:
+Responsibilities include:
 
 - Facilitate meetings and set up the agenda
-- Ensure that discussions align with the yearly startegic goals previously approved by the Steering Committee
-- Provide quarterly updates to the Steering Committee and seeking guidance when necessary
+- Ensure that discussions align with the yearly strategic goals previously approved by the Steering Committee
+- Provide quarterly updates to the Steering Committee and seek guidance when necessary
 
 
 #### Steering Committee Members
@@ -43,7 +43,7 @@ Responsibilities include:
 - Approve major decisions
 - Resolve conflicts
 
-#### Working Group Contirbutors
+#### Working Group Contributors
 
 Contributors are the active participants of the working groups. They participate in discussions, contribute code or documentation, and other resources, collaborating with other participants to achieve the working group's strategic objectives
 


### PR DESCRIPTION
This PR adds a new markdown called playbook.md which should include detailed documentation of the foundation's processes. (e.g. instructions on how to join a working group, file issues, or responsibilities of chairs).

The initial draft includes:

- Working Groups Guidelines
   -  Principles
   -  Roles
- Communication Channel Guidelines
- [Linux Foundation's Policies](https://www.linuxfoundation.org/legal/policies)