### PR TITLE
Add version to file, remove from filename

### DIFF
--- a/Technical_Charter.adoc
+++ b/Technical_Charter.adoc
@@ -2,6 +2,7 @@
 
 > The purpose of having a charter for the Developer Relations Foundation is to help people understand its mission and scope. The DevRel Foundation Charter is a living document, allowing the community to propose changes and updates as the project evolves.
 
+Version 2.0
 Adopted July 9, 2025
 
 :toc:


### PR DESCRIPTION
* Add current version to file content
* Remove from filename

Reason: When version of the charter is bumped in the filename, all links to the charter break.  